### PR TITLE
feat: make close icon button hide AudioEqualizer UI via state #27

### DIFF
--- a/UI/src/components/equalizer/AudioEqualizer.tsx
+++ b/UI/src/components/equalizer/AudioEqualizer.tsx
@@ -292,10 +292,12 @@ export const AudioEqualizer: React.FC<AudioEqualizerProps> = ({
           
           {/* Close Button */}
           <button
+            onClick={() => window.close()}
             className={cn(
               "p-2 rounded-lg text-eq-text-dim hover:text-eq-accent",
               "hover:bg-eq-surface-light transition-all duration-200",
             )}
+            title="Close extension popup"
           >
             <PanelTopClose size={20} />
           </button>


### PR DESCRIPTION
- Add onClick handler to close button in AudioEqualizer.tsx to close the extension popup using window.close()
- Tested the close button by opening the extension popup and clicking the close icon 
- closes #27
